### PR TITLE
Better ramp handling

### DIFF
--- a/FHEM/32_WifiLight.pm
+++ b/FHEM/32_WifiLight.pm
@@ -549,11 +549,11 @@ WifiLight_Set(@)
   
   if (($cmd eq 'HSV') || ($cmd eq 'RGB') || ($cmd eq 'dim'))
   {
-    $args[1] = AttrVal($ledDevice->{NAME}, "defaultRamp", 0) if !($args[1]);
+    $args[1] = AttrVal($ledDevice->{NAME}, "defaultRamp", 0) if !defined($args[1]);
   }
   else
   {
-    $args[0] = AttrVal($ledDevice->{NAME}, "defaultRamp", 0) if !($args[0]);
+    $args[0] = AttrVal($ledDevice->{NAME}, "defaultRamp", 0) if !defined($args[0]);
   }
 
   if ($cmd eq 'on')

--- a/FHEM/32_WifiLight.pm
+++ b/FHEM/32_WifiLight.pm
@@ -561,7 +561,7 @@ WifiLight_Set(@)
     WifiLight_HighLevelCmdQueue_Clear($ledDevice);
     if (defined($args[0]))
     {
-      return "usage: set $name on [seconds]" if ($args[0] !~ /^\d+$/);
+      return "usage: set $name on [seconds]" if ($args[0] !~ /^\d?.?\d+$/);
       $ramp = $args[0];
     }
     return WifiLight_RGBWLD316_On($ledDevice, $ramp) if (($ledDevice->{LEDTYPE} eq 'RGBW') && ($ledDevice->{CONNECTION} eq 'LD316'));
@@ -583,7 +583,7 @@ WifiLight_Set(@)
     WifiLight_HighLevelCmdQueue_Clear($ledDevice);
     if (defined($args[0]))
     {
-      return "usage: set $name off [seconds]" if ($args[0] !~ /^\d+$/);
+      return "usage: set $name off [seconds]" if ($args[0] !~ /^\d?.?\d+$/);
       $ramp = $args[0];
     }
     return WifiLight_RGBWLD316_Off($ledDevice, $ramp) if (($ledDevice->{LEDTYPE} eq 'RGBW') && ($ledDevice->{CONNECTION} eq 'LD316'));
@@ -646,7 +646,7 @@ WifiLight_Set(@)
     return "usage: set $name dim level [seconds]" if !($args[0] ~~ [0..100]);
     if (defined($args[1]))
     {
-      return "usage: set $name dim level [seconds] [q]" if ($args[1] !~ /^\d+$/);
+      return "usage: set $name dim level [seconds] [q]" if ($args[1] !~ /^\d?.?\d+$/);
       $ramp = $args[1];
     }
     if (defined($args[2]))
@@ -689,7 +689,7 @@ WifiLight_Set(@)
     
     if (defined($args[1]))
     {
-      return "usage: set $name HSV H,S,V seconds flags programm" if ($args[1] !~ /^\d+$/);
+      return "usage: set $name HSV H,S,V seconds flags programm" if ($args[1] !~ /^\d?.?\d+$/);
       $ramp = $args[1];
     }
     if (defined($args[2]))


### PR DESCRIPTION
I've fixed two issues with the handling of the ramp parameter:

1. When setting the "defaultRamp" attribute it's impossible to set a new color with no ramping (e.g. a ramp value of 0). Trying "set … HSV 42,23,50 0" would simply apply the defaultRamp value instead of 0.
2. The ramp parameter/defaultRamp attribute doesn't accept/work with float values. Especially a defaultRamp is most useful in the sub-second range (something like 0.2 seconds) to give a smoother feeling to the user without undue delay.

Note: I've no earthly idea how to handle the controls_wifilight.txt file, therefore I haven't touched it.